### PR TITLE
Build an xdg-app out of liferea on webkit2

### DIFF
--- a/net.sourceforge.liferea.json
+++ b/net.sourceforge.liferea.json
@@ -1,0 +1,48 @@
+{
+    "id": "net.sourceforge.liferea",
+    "branch": "master",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.20",
+    "sdk": "org.gnome.Sdk",
+    "command": "liferea",
+    "rename-desktop-file": "liferea.desktop",
+    "rename-appdata-file": "liferea.appdata.xml",
+    "rename-icon": "liferea",
+    "finish-args": [
+        "--share=ipc", "--socket=x11",
+        "--socket=wayland",
+        "--share=network",
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "cleanup": ["/include", "/lib/pkgconfig", "/share/pkgconfig", "/share/aclocal", "/man", "/share/man", "/share/gtk-doc", "/share/vala", "*.la", "*.a"],
+    "modules": [
+        {
+            "name": "libpeas",
+            "cleanup": [ "/bin/*", "/lib/peas-demo" ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://git.gnome.org/libpeas"
+                }
+            ]
+        },
+        {
+            "name": "liferea",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/gcampax/liferea.git",
+                    "branch": "webkit2"
+                }
+            ]
+        }
+    ]
+}

--- a/src/ui/liferea_htmlview.c
+++ b/src/ui/liferea_htmlview.c
@@ -199,8 +199,6 @@ liferea_htmlview_class_init (LifereaHtmlViewClass *klass)
 		1,
 		G_TYPE_STRING);
 
-	htmlview_get_impl ()->init ();
-
 	g_type_class_add_private (object_class, sizeof (LifereaHtmlViewPrivate));
 }
 
@@ -208,10 +206,17 @@ static void
 liferea_htmlview_init (LifereaHtmlView *htmlview)
 {
 	GtkWidget *widget, *image;
+	static gboolean htmlview_initialized;
 
 	htmlview->priv = LIFEREA_HTMLVIEW_GET_PRIVATE (htmlview);
 	htmlview->priv->internal = FALSE;
 	htmlview->priv->impl = htmlview_get_impl ();
+
+	if (!htmlview_initialized) {
+		htmlview->priv->impl->init ();
+		htmlview_initialized = TRUE;
+	}
+
 	htmlview->priv->renderWidget = RENDERER (htmlview)->create (htmlview);
 	htmlview->priv->container = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	htmlview->priv->history = browser_history_new ();


### PR DESCRIPTION
xdg-apps is the new cross-distro packaging format for apps with potentially bundled deps.

This PR makes sure liferea builds in the xdg-app environment, and adds the metadata to build one.
Use
xdg-app-builder -v ./xdg-app net.sourceforge.liferea.json --repo ./xdg-app-repo
xdg-app build-bundle ./xdg-app-repo net.sourceforce.liferea.xdgapp net.sourceforge.liferea master
to build
(produces a *.xdgapp file that can be installed with gnome-software 3.20+)

This is against the webkit2 branch instead of master because it uses the GNOME SDK, which includes webkit 2 already, and not webkit 1 which is deprecated and dangerous.
